### PR TITLE
use context when logging without context

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -142,10 +142,7 @@ func WithLogger(ctx context.Context, logger *Logger) context.Context {
 
 func FromContext(ctx context.Context) *Logger {
 	if logger, ok := ctx.Value(loggerKey{}).(*Logger); ok {
-		logger.ctx = ctx
-		return logger
+		return &Logger{Logger: logger.Logger, ctx: ctx}
 	}
-	l := DefaultLogger()
-	l.ctx = ctx
-	return l
+	return &Logger{Logger: DefaultLogger().Logger, ctx: ctx}
 }


### PR DESCRIPTION
`slogctx.FromContext(ctx).Info("hello")` and `Infof` now act as if it was called with `InfoContext` with the original context.

`InfoContext` is unaffected.