### PR TITLE
add Fatal{Context}{f}

### DIFF
--- a/log.go
+++ b/log.go
@@ -3,6 +3,7 @@ package clog
 import (
 	"context"
 	"log/slog"
+	"os"
 )
 
 // Info calls Info on the default logger.
@@ -88,4 +89,28 @@ func Debugf(format string, args ...any) {
 // If a Logger is found in the context, it will be used.
 func DebugContextf(ctx context.Context, format string, args ...any) {
 	wrapf(ctx, FromContext(ctx), slog.LevelDebug, format, args...)
+}
+
+// Fatal calls Error on the default logger, then exits.
+func Fatal(msg string, args ...any) {
+	wrap(context.Background(), DefaultLogger(), slog.LevelError, msg, args...)
+	os.Exit(1)
+}
+
+// FatalContext calls ErrorContext on the context logger, then exits.
+func FatalContext(ctx context.Context, msg string, args ...any) {
+	wrap(ctx, FromContext(ctx), slog.LevelError, msg, args...)
+	os.Exit(1)
+}
+
+// Fatalf calls Errorf on the default logger, then exits.
+func Fatalf(format string, args ...any) {
+	wrapf(context.Background(), DefaultLogger(), slog.LevelError, format, args...)
+	os.Exit(1)
+}
+
+// FatalContextf calls ErrorContextf on the context logger, then exits.
+func FatalContextf(ctx context.Context, format string, args ...any) {
+	wrapf(ctx, FromContext(ctx), slog.LevelError, format, args...)
+	os.Exit(1)
 }

--- a/logger.go
+++ b/logger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"runtime"
 	"time"
 )
@@ -84,6 +85,30 @@ func (l *Logger) Debugf(format string, args ...any) {
 // DebugContextf logs at LevelDebug with the given context, format and arguments.
 func (l *Logger) DebugContextf(ctx context.Context, format string, args ...any) {
 	wrapf(ctx, l, slog.LevelDebug, format, args...)
+}
+
+// Fatalf logs at LevelError with the given format and arguments, then exits.
+func (l *Logger) Fatalf(format string, args ...any) {
+	wrapf(context.Background(), l, slog.LevelError, format, args...)
+	os.Exit(1)
+}
+
+// Fatal logs at LevelError with the given message, then exits.
+func (l *Logger) Fatal(msg string) {
+	wrapf(context.Background(), l, slog.LevelError, msg)
+	os.Exit(1)
+}
+
+// FatalfContextf logs at LevelError with the given context, format and arguments, then exits.
+func (l *Logger) FatalContextf(ctx context.Context, format string, args ...any) {
+	wrapf(ctx, l, slog.LevelError, format, args...)
+	os.Exit(1)
+}
+
+// FatalfContext logs at LevelError with the given context and message, then exits.
+func (l *Logger) FatalContext(ctx context.Context, msg string) {
+	wrapf(ctx, l, slog.LevelError, msg)
+	os.Exit(1)
 }
 
 // Base returns the underlying [slog.Logger].

--- a/logger.go
+++ b/logger.go
@@ -106,8 +106,8 @@ func (l *Logger) FatalContextf(ctx context.Context, format string, args ...any) 
 }
 
 // FatalfContext logs at LevelError with the given context and message, then exits.
-func (l *Logger) FatalContext(ctx context.Context, msg string) {
-	wrapf(ctx, l, slog.LevelError, msg)
+func (l *Logger) FatalContext(ctx context.Context, msg string, args ...any) {
+	wrap(ctx, l, slog.LevelError, msg, args...)
 	os.Exit(1)
 }
 

--- a/logger.go
+++ b/logger.go
@@ -94,8 +94,8 @@ func (l *Logger) Fatalf(format string, args ...any) {
 }
 
 // Fatal logs at LevelError with the given message, then exits.
-func (l *Logger) Fatal(msg string) {
-	wrapf(context.Background(), l, slog.LevelError, msg)
+func (l *Logger) Fatal(msg string, args ...any) {
+	wrap(context.Background(), l, slog.LevelError, msg, args...)
 	os.Exit(1)
 }
 


### PR DESCRIPTION
This adds `clog.Fatal{Context}{f}`, and `clog.FromContext(ctx).Fatal{Context}{f}`

`Fatal` logs at `LevelError` then calls `os.Exit(1)`, like stdlib `log.Fatal`: https://cs.opensource.google/go/go/+/refs/tags/go1.21.6:src/log/log.go;l=413