### PR TITLE
Preserve context in logger when calling FromContext.

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -42,3 +42,17 @@ func ExampleLogger() {
 	// level=INFO msg="hello world" a=b foo=bar
 	// level=ERROR msg=asdf a=b baz=true
 }
+
+func ExampleFromContext_preserveContext() {
+	log := clog.NewLogger(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		// Remove time for repeatable results
+		ReplaceAttr: slogtest.RemoveTime,
+	}))).With("foo", "bar")
+	ctx := clog.WithLogger(context.Background(), log)
+
+	// Previous context values are preserved when using FromContext
+	clog.FromContext(ctx).Info("hello world")
+
+	// Output:
+	// level=INFO msg="hello world" foo=bar
+}


### PR DESCRIPTION
Modification of #5 

Allows for passing through the logger while still using default Info methods. InfoContext remains to override the context with another value.

This changes the stored context value to store the underlying slog.Logger instead of the wrapped logger so we're not storing a context within a context.
