### PR TITLE
slogtest: Allow passing in logging config options.

### DIFF
--- a/slogtest/slogtest.go
+++ b/slogtest/slogtest.go
@@ -26,9 +26,23 @@ type Logger interface {
 	Logf(format string, args ...any)
 }
 
-// TestLogger gets a logger to use in unit and end to end tests
+// TestLogger gets a logger to use in unit and end to end tests.
+// This logger is configured to log at debug level.
 func TestLogger(t Logger) *clog.Logger {
-	return clog.New(slog.NewTextHandler(&logAdapter{l: t}, nil))
+	return TestLoggerWithOptions(t, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})
+}
+
+// TestLoggerWithOptions gets a logger to use in unit and end to end tests.
+func TestLoggerWithOptions(t Logger, opts *slog.HandlerOptions) *clog.Logger {
+	return clog.New(slog.NewTextHandler(&logAdapter{l: t}, opts))
+}
+
+// Context returns a context with a logger to be used in tests.
+// This is equivalent to TestContextWithLogger.
+func Context(t Logger) context.Context {
+	return TestContextWithLogger(t)
 }
 
 // TestContextWithLogger returns a context with a logger to be used in tests


### PR DESCRIPTION
- Enables debug logging by default.
- Adds `TestLoggerWithOptions` to allow overriding default config.
- Adds `Context` as a shorthand for TestContextWithLogger
   (e.g. `slogtest.TestContextWithLogger(t)` -> `slogtest.Context(t)`)