### PR TITLE
improve slogtest

### DIFF
--- a/slogtest/slogtest.go
+++ b/slogtest/slogtest.go
@@ -18,6 +18,7 @@ type logAdapter struct {
 }
 
 func (l *logAdapter) Write(b []byte) (int, error) {
+	l.l.Helper()
 	l.l.Log(strings.TrimSuffix(string(b), "\n"))
 	return len(b), nil
 }
@@ -25,12 +26,24 @@ func (l *logAdapter) Write(b []byte) (int, error) {
 type Logger interface {
 	Log(args ...any)
 	Logf(format string, args ...any)
+	Helper()
 }
 
 // TestLogger gets a logger to use in unit and end to end tests.
 // This logger is configured to log at debug level.
 func TestLogger(t Logger) *clog.Logger {
-	return clog.New(slog.NewTextHandler(&logAdapter{l: t}, nil))
+	return clog.New(slog.NewTextHandler(&logAdapter{l: t}, &slog.HandlerOptions{AddSource: true}))
+}
+
+// TestLoggerWithOptions gets a logger to use in unit and end to end tests.
+func TestLoggerWithOptions(t Logger, opts *slog.HandlerOptions) *clog.Logger {
+	return clog.New(slog.NewTextHandler(&logAdapter{l: t}, opts))
+}
+
+// Context returns a context with a logger to be used in tests.
+// This is equivalent to TestContextWithLogger.
+func Context(t Logger) context.Context {
+	return TestContextWithLogger(t)
 }
 
 // TestContextWithLogger returns a context with a logger to be used in tests

--- a/slogtest/slogtest.go
+++ b/slogtest/slogtest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"strings"
 
 	"github.com/chainguard-dev/clog"
 )
@@ -17,13 +18,11 @@ type logAdapter struct {
 }
 
 func (l *logAdapter) Write(b []byte) (int, error) {
-	l.l.Helper()
-	l.l.Log(string(b))
+	l.l.Log(strings.TrimSuffix(string(b), "\n"))
 	return len(b), nil
 }
 
 type Logger interface {
-	Helper()
 	Log(args ...any)
 	Logf(format string, args ...any)
 }
@@ -31,7 +30,7 @@ type Logger interface {
 // TestLogger gets a logger to use in unit and end to end tests.
 // This logger is configured to log at debug level.
 func TestLogger(t Logger) *clog.Logger {
-	return clog.New(slog.NewTextHandler(&logAdapter{l: t}, &slog.HandlerOptions{}))
+	return clog.New(slog.NewTextHandler(&logAdapter{l: t}, nil))
 }
 
 // TestContextWithLogger returns a context with a logger to be used in tests

--- a/slogtest/slogtest.go
+++ b/slogtest/slogtest.go
@@ -17,11 +17,13 @@ type logAdapter struct {
 }
 
 func (l *logAdapter) Write(b []byte) (int, error) {
+	l.l.Helper()
 	l.l.Log(string(b))
 	return len(b), nil
 }
 
 type Logger interface {
+	Helper()
 	Log(args ...any)
 	Logf(format string, args ...any)
 }
@@ -29,20 +31,7 @@ type Logger interface {
 // TestLogger gets a logger to use in unit and end to end tests.
 // This logger is configured to log at debug level.
 func TestLogger(t Logger) *clog.Logger {
-	return TestLoggerWithOptions(t, &slog.HandlerOptions{
-		Level: slog.LevelDebug,
-	})
-}
-
-// TestLoggerWithOptions gets a logger to use in unit and end to end tests.
-func TestLoggerWithOptions(t Logger, opts *slog.HandlerOptions) *clog.Logger {
-	return clog.New(slog.NewTextHandler(&logAdapter{l: t}, opts))
-}
-
-// Context returns a context with a logger to be used in tests.
-// This is equivalent to TestContextWithLogger.
-func Context(t Logger) context.Context {
-	return TestContextWithLogger(t)
+	return clog.New(slog.NewTextHandler(&logAdapter{l: t}, &slog.HandlerOptions{}))
 }
 
 // TestContextWithLogger returns a context with a logger to be used in tests

--- a/slogtest/slogtest.go
+++ b/slogtest/slogtest.go
@@ -1,3 +1,16 @@
+// Package slogtest provides utilities for emitting test logs using clog.
+//
+//	func TestExample(t *testing.T) {
+//		ctx := slogtest.Context(t)
+//		clog.FromContext(ctx).With("foo", "bar").Info("hello world")
+//	}
+//
+// This produces the following test output:
+//
+//	=== RUN   TestExample
+//		slogtest.go:24: level=INFO source=/path/to/example_test.go:13 msg="hello world" foo=bar
+//
+// This package is intended to be used in tests only.
 package slogtest
 
 import (

--- a/slogtest/slogtest.go
+++ b/slogtest/slogtest.go
@@ -53,15 +53,14 @@ func TestLoggerWithOptions(t Logger, opts *slog.HandlerOptions) *clog.Logger {
 }
 
 // Context returns a context with a logger to be used in tests.
-// This is equivalent to TestContextWithLogger.
 func Context(t Logger) context.Context {
-	return TestContextWithLogger(t)
+	return clog.WithLogger(context.Background(), TestLogger(t))
 }
 
 // TestContextWithLogger returns a context with a logger to be used in tests
-func TestContextWithLogger(t Logger) context.Context {
-	return clog.WithLogger(context.Background(), TestLogger(t))
-}
+//
+// Deprecated: Use Context instead.
+func TestContextWithLogger(t Logger) context.Context { return Context(t) }
 
 // RemoveTime removes the top-level time attribute.
 // It is intended to be used as a ReplaceAttr function,

--- a/slogtest/slogtest_test.go
+++ b/slogtest/slogtest_test.go
@@ -10,4 +10,6 @@ func TestSlogTest(t *testing.T) {
 	ctx := TestContextWithLogger(t)
 
 	clog.FromContext(ctx).With("foo", "bar").Infof("hello world")
+	clog.FromContext(ctx).With("bar", "baz").Infof("me again")
+	clog.FromContext(ctx).With("baz", true).Infof("okay last one")
 }

--- a/slogtest/slogtest_test.go
+++ b/slogtest/slogtest_test.go
@@ -1,13 +1,14 @@
-package slogtest
+package slogtest_test
 
 import (
 	"testing"
 
 	"github.com/chainguard-dev/clog"
+	"github.com/chainguard-dev/clog/slogtest"
 )
 
 func TestSlogTest(t *testing.T) {
-	ctx := TestContextWithLogger(t)
+	ctx := slogtest.Context(t)
 
 	clog.FromContext(ctx).With("foo", "bar").Infof("hello world")
 	clog.FromContext(ctx).With("bar", "baz").Infof("me again")

--- a/slogtest/slogtest_test.go
+++ b/slogtest/slogtest_test.go
@@ -1,0 +1,13 @@
+package slogtest
+
+import (
+	"testing"
+
+	"github.com/chainguard-dev/clog"
+)
+
+func TestSlogTest(t *testing.T) {
+	ctx := TestContextWithLogger(t)
+
+	clog.FromContext(ctx).With("foo", "bar").Infof("hello world")
+}


### PR DESCRIPTION
Without the slogtest change, with the newly added test:

```
go test ./slogtest/ -v                
=== RUN   TestSlogTest
    slogtest.go:20: time=2024-02-12T16:50:56.437-05:00 level=INFO msg="hello world" foo=bar
        
--- PASS: TestSlogTest (0.00s)
PASS
ok      github.com/chainguard-dev/clog/slogtest 0.116s
```

With this change:

```
go test ./slogtest -v
=== RUN   TestSlogTest
    slogtest.go:31: level=INFO source=/Users/jason/git/clog/slogtest/slogtest_test.go:13 msg="hello world" foo=bar
    slogtest.go:31: level=INFO source=/Users/jason/git/clog/slogtest/slogtest_test.go:14 msg="me again" bar=baz
    slogtest.go:31: level=INFO source=/Users/jason/git/clog/slogtest/slogtest_test.go:15 msg="okay last one" baz=true
```
