### PR TITLE
gcp/trace: limit project ID lookups, add tests

### DIFF
--- a/gcp/trace.go
+++ b/gcp/trace.go
@@ -5,9 +5,41 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
+	"runtime"
 	"strings"
+	"sync"
+	"time"
+)
+
+func insideTest() bool {
+	// Ask runtime.Callers for up to 10 PCs, including runtime.Callers itself.
+	pc := make([]uintptr, 10)
+	n := runtime.Callers(0, pc)
+	if n == 0 {
+		slog.Debug("WithCloudTraceContext: no PCs available")
+		return true
+	}
+	frames := runtime.CallersFrames(pc[:n])
+	for {
+		frame, more := frames.Next()
+		if !more {
+			break
+		}
+		if strings.HasPrefix(frame.Function, "testing.") &&
+			strings.HasSuffix(frame.File, "src/testing/testing.go") {
+			slog.Debug("WithCloudTraceContext: inside test", "function", frame.Function, "file", frame.File, "line", frame.Line)
+			return true
+		}
+	}
+	return false
+}
+
+var (
+	projectID  string
+	lookupOnce sync.Once
 )
 
 // WithCloudTraceContext returns an http.handler that adds the GCP Cloud Trace
@@ -15,46 +47,63 @@ import (
 // request log.
 func WithCloudTraceContext(h http.Handler) http.Handler {
 	// Get the project ID from the environment if specified
-	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
-	if projectID == "" {
-		// By default use the metadata IP; otherwise use the environment variable
-		// for consistency with https://pkg.go.dev/cloud.google.com/go/compute/metadata#Client.Get
-		host := "169.254.169.254"
-		if h := os.Getenv("GCE_METADATA_HOST"); h != "" {
-			host = h
-		}
-		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s/computeMetadata/v1/project/project-id", host), nil)
-		if err != nil {
-			slog.Debug("WithCloudTraceContext: could not get GCP project ID from metadata server", "err", err)
-			return h
-		}
-		req.Header.Set("Metadata-Flavor", "Google")
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			slog.Debug("WithCloudTraceContext: could not get GCP project ID from metadata server", "err", err)
-			return h
-		}
-		if resp.StatusCode != http.StatusOK {
-			slog.Debug("WithCloudTraceContext: could not get GCP project ID from metadata server", "code", resp.StatusCode, "status", resp.Status)
-			return h
-		}
-		defer resp.Body.Close()
-		all, err := io.ReadAll(resp.Body)
-		if err != nil {
-			slog.Debug("WithCloudTraceContext: could not get GCP project ID from metadata server", "err", err)
-			return h
-		}
-		projectID = string(all)
+	fromEnv := os.Getenv("GOOGLE_CLOUD_PROJECT")
+	if fromEnv != "" {
+		projectID = fromEnv
+	} else {
+		lookupOnce.Do(func() {
+			if insideTest() {
+				slog.Debug("WithCloudTraceContext: inside test, not looking up project ID")
+				return
+			}
+
+			// By default use the metadata IP; otherwise use the environment variable
+			// for consistency with https://pkg.go.dev/cloud.google.com/go/compute/metadata#Client.Get
+			host := "169.254.169.254"
+			if h := os.Getenv("GCE_METADATA_HOST"); h != "" {
+				host = h
+			}
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s/computeMetadata/v1/project/project-id", host), nil)
+			if err != nil {
+				slog.Debug("WithCloudTraceContext: could not get GCP project ID from metadata server", "err", err)
+				return
+			}
+			req.Header.Set("Metadata-Flavor", "Google")
+			resp, err := (&http.Client{ // Timeouts copied from https://pkg.go.dev/cloud.google.com/go/compute/metadata#Get
+				Transport: &http.Transport{
+					Dial: (&net.Dialer{Timeout: 2 * time.Second}).Dial,
+				},
+				Timeout: 5 * time.Second,
+			}).Do(req)
+			if err != nil {
+				slog.Debug("WithCloudTraceContext: could not get GCP project ID from metadata server", "err", err)
+				return
+			}
+			if resp.StatusCode != http.StatusOK {
+				slog.Debug("WithCloudTraceContext: could not get GCP project ID from metadata server", "code", resp.StatusCode, "status", resp.Status)
+				return
+			}
+			defer resp.Body.Close()
+			all, err := io.ReadAll(resp.Body)
+			if err != nil {
+				slog.Debug("WithCloudTraceContext: could not get GCP project ID from metadata server", "err", err)
+				return
+			}
+			projectID = string(all)
+		})
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var trace string
-		traceHeader := r.Header.Get("X-Cloud-Trace-Context")
-		traceParts := strings.Split(traceHeader, "/")
-		if len(traceParts) > 0 && len(traceParts[0]) > 0 {
-			trace = fmt.Sprintf("projects/%s/traces/%s", projectID, traceParts[0])
+		if projectID != "" {
+			var trace string
+			traceHeader := r.Header.Get("X-Cloud-Trace-Context")
+			traceParts := strings.Split(traceHeader, "/")
+			if len(traceParts) > 0 && len(traceParts[0]) > 0 {
+				trace = fmt.Sprintf("projects/%s/traces/%s", projectID, traceParts[0])
+			}
+			r = r.WithContext(context.WithValue(r.Context(), "trace", trace))
 		}
-		h.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), "trace", trace)))
+		h.ServeHTTP(w, r)
 	})
 }
 

--- a/gcp/trace_test.go
+++ b/gcp/trace_test.go
@@ -1,0 +1,69 @@
+package gcp
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/chainguard-dev/clog"
+)
+
+func TestTrace(t *testing.T) {
+	// This ensures the metadata server is not called at all during tests.
+	md := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("metadata server called")
+	}))
+	defer md.Close()
+	t.Setenv("GCE_METADATA_HOST", md.URL)
+
+	slog.SetDefault(slog.New(NewHandler(slog.LevelDebug)))
+	for _, c := range []struct {
+		name      string
+		env       string
+		wantTrace bool
+	}{
+		{"no env set", "", false},
+		{"env set", "my-project", true},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv("GOOGLE_CLOUD_PROJECT", c.env)
+
+			// Set up a server that logs a message with trace context added.
+			slog.SetDefault(slog.New(NewHandler(slog.LevelDebug)))
+			h := WithCloudTraceContext(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				ctx := r.Context()
+				clog.InfoContext(ctx, "hello world")
+
+				// TODO: This doesn't propagate the trace context to the logger.
+				//clog.FromContext(ctx).Info("hello world")
+
+				if r.Header.Get("X-Cloud-Trace-Context") == "" {
+					t.Error("got empty trace context header, want non-empty")
+				}
+
+				if found := ctx.Value("trace") != nil; found != c.wantTrace {
+					t.Fatalf("got trace context %t, want %t", found, c.wantTrace)
+					if c.wantTrace {
+						if trace := ctx.Value("trace"); !strings.Contains(trace.(string), "/"+c.env+"/") {
+							t.Errorf("got trace context %q, want %q", trace, c.env)
+						}
+					}
+				}
+			}))
+			srv := httptest.NewServer(h)
+			defer srv.Close()
+
+			// Send a request to the server with a trace context header.
+			req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("X-Cloud-Trace-Context", "trace/id/yay")
+			if _, err := http.DefaultClient.Do(req); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
If `WithCloudTraceContext` is called from tests where GCE metadata isn't available, it hangs indefinitely, which is not a great experience.

Some improvements in this PR:

- project ID lookup will only be performed once, instead of each time `WithCloudTraceContext` is called
- if we detect we're being called in tests, the project ID won't be looked up and we won't log with trace context
- add a standard short timeout to metadata requests, consistent with the official client

Also add a test that shows that the `trace` context value is set when the project ID env var is set; because this logging must go to stderr, we can't easily test what actually gets logged, but we can show it working in the verbose output:

```
go test ./gcp -v -count=1
=== RUN   TestTrace
=== RUN   TestTrace/no_env_set
{"time":"2024-02-12T20:22:14.059143-05:00","severity":"DEBUG","logging.googleapis.com/sourceLocation":{"function":"github.com/chainguard-dev/clog/gcp.insideTest","file":"/Users/jason/git/clog/gcp/trace.go","line":33},"message":"WithCloudTraceContext: inside test","function":"testing.tRunner","file":"/opt/homebrew/Cellar/go/1.21.5/libexec/src/testing/testing.go","line":1595}
{"time":"2024-02-12T20:22:14.059343-05:00","severity":"DEBUG","logging.googleapis.com/sourceLocation":{"function":"github.com/chainguard-dev/clog/gcp.WithCloudTraceContext.func1","file":"/Users/jason/git/clog/gcp/trace.go","line":56},"message":"WithCloudTraceContext: inside test, not looking up project ID"}
{"time":"2024-02-12T20:22:14.060156-05:00","severity":"INFO","logging.googleapis.com/sourceLocation":{"function":"github.com/chainguard-dev/clog/gcp.TestTrace.func2.1","file":"/Users/jason/git/clog/gcp/trace_test.go","line":37},"message":"hello world"}
=== RUN   TestTrace/env_set
{"time":"2024-02-12T20:22:14.060678-05:00","severity":"INFO","logging.googleapis.com/sourceLocation":{"function":"github.com/chainguard-dev/clog/gcp.TestTrace.func2.1","file":"/Users/jason/git/clog/gcp/trace_test.go","line":37},"message":"hello world","logging.googleapis.com/trace":"projects/my-project/traces/trace"}
--- PASS: TestTrace (0.00s)
    --- PASS: TestTrace/no_env_set (0.00s)
    --- PASS: TestTrace/env_set (0.00s)
PASS
ok      github.com/chainguard-dev/clog/gcp      0.166s
```

The test also attempts to check that GCE metadata isn't requested.

Through this work I've found that `clog.FromContext(ctx).Info("hello")` doesn't carry the `trace` context value, possibly related to https://github.com/chainguard-dev/clog/pull/11