### PR TITLE
Use `traceparent` instead of `X-Cloud-Trace-Context`

### DIFF
--- a/gcp/trace.go
+++ b/gcp/trace.go
@@ -96,10 +96,10 @@ func WithCloudTraceContext(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if projectID != "" {
 			var trace string
-			traceHeader := r.Header.Get("X-Cloud-Trace-Context")
-			traceParts := strings.Split(traceHeader, "/")
-			if len(traceParts) > 0 && len(traceParts[0]) > 0 {
-				trace = fmt.Sprintf("projects/%s/traces/%s", projectID, traceParts[0])
+			traceHeader := r.Header.Get("traceparent")
+			traceID := parseTraceFromW3CHeader(traceHeader)
+			if traceID != "" {
+				trace = fmt.Sprintf("projects/%s/traces/%s", projectID, traceID)
 			}
 			r = r.WithContext(context.WithValue(r.Context(), "trace", trace))
 		}
@@ -113,4 +113,12 @@ func traceFromContext(ctx context.Context) string {
 		return ""
 	}
 	return trace.(string)
+}
+
+func parseTraceFromW3CHeader(traceparent string) string {
+	traceParts := strings.Split(traceparent, "-")
+	if len(traceParts) > 1 {
+		return traceParts[1]
+	}
+	return ""
 }


### PR DESCRIPTION
According to https://cloud.google.com/trace/docs/trace-context#http-requests,  `X-Cloud-Trace-Context` is a legacy header that precedes the W3C standard `traceparent` header. Google Cloud services that support trace context propagation typically support both the `traceparent` and the legacy `X-Cloud-Trace-Context` header.

Switching to use this so that we don't have to use the legacy header `X-Cloud-Trace-Context` when restoring trace context header for pubsub eventing, but only using `traceparent` every where.