### PR TITLE
slogtest: demonstrate use of t.Context()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/chainguard-dev/clog
 
-go 1.22.4
+go 1.24.4

--- a/slogtest/another_test.go
+++ b/slogtest/another_test.go
@@ -1,0 +1,9 @@
+package slogtest_test
+
+import (
+	"context"
+
+	"github.com/chainguard-dev/clog"
+)
+
+func fn(ctx context.Context) { clog.FromContext(ctx).With("foo", "bar").Infof("hello from fn") }

--- a/slogtest/slogtest.go
+++ b/slogtest/slogtest.go
@@ -11,6 +11,11 @@
 //		slogtest.go:24: level=INFO source=/path/to/example_test.go:13 msg="hello world" foo=bar
 //
 // This package is intended to be used in tests only.
+//
+// In Go 1.24, *testing.T etc added `t.Context()` methods, which return a
+// context.Context to be used in tests. You can use `clog.FromContext(t.Context())`
+// to get a logger in tests instead, and configure the default logger to get the
+// same logging behavior as `slogtest.Context(t)`.
 package slogtest
 
 import (
@@ -36,7 +41,10 @@ var _ Logger = (*testing.T)(nil)
 var _ Logger = (*testing.B)(nil)
 var _ Logger = (*testing.F)(nil)
 
-type Logger interface{ Log(args ...any) }
+type Logger interface {
+	Log(args ...any)
+	Context() context.Context
+}
 
 // TestLogger gets a logger to use in unit and end to end tests.
 // This logger is configured to log at debug level.
@@ -55,7 +63,7 @@ func TestLoggerWithOptions(t Logger, opts *slog.HandlerOptions) *clog.Logger {
 
 // Context returns a context with a logger to be used in tests.
 func Context(t Logger) context.Context {
-	return clog.WithLogger(context.Background(), TestLogger(t))
+	return clog.WithLogger(t.Context(), TestLogger(t))
 }
 
 // TestContextWithLogger returns a context with a logger to be used in tests

--- a/slogtest/slogtest_test.go
+++ b/slogtest/slogtest_test.go
@@ -1,6 +1,7 @@
 package slogtest_test
 
 import (
+	"log/slog"
 	"testing"
 
 	"github.com/chainguard-dev/clog"
@@ -18,4 +19,23 @@ func TestSlogTest(t *testing.T) {
 	clog.FromContext(ctx).Info("hello info")
 	clog.FromContext(ctx).Warn("hello warn")
 	clog.FromContext(ctx).Error("hello error")
+
+	fn(ctx)
+}
+
+// TestSlogTestTContext tests the use of t.Context() in Go 1.24+.
+func TestSlogTestTContext(t *testing.T) {
+	ctx := t.Context()
+	slog.SetDefault(slog.New(slogtest.TestLogger(t).Handler()))
+
+	clog.FromContext(ctx).With("foo", "bar").Infof("hello world")
+	clog.FromContext(ctx).With("bar", "baz").Infof("me again")
+	clog.FromContext(ctx).With("baz", true).Infof("okay last one")
+
+	clog.FromContext(ctx).Debug("hello debug")
+	clog.FromContext(ctx).Info("hello info")
+	clog.FromContext(ctx).Warn("hello warn")
+	clog.FromContext(ctx).Error("hello error")
+
+	fn(ctx)
 }


### PR DESCRIPTION
Go 1.24 added [`t.Context()`](https://pkg.go.dev/testing#T.Context), which is presumably more idiomatic to use with clog than our own slogtest package.

This PR adds a comment mentioning `t.Context` and demonstrates how to get `t.Context` to have the same behavior as `slogtest.Context(t)`.

Without the `slog.SetDefault` the behavior is different:

```
go test -trimpath ./slogtest -run=SlogTest -v             
=== RUN   TestSlogTest
    slogtest.go:36: level=INFO source=github.com/chainguard-dev/clog/slogtest/slogtest_test.go:13 msg="hello world" foo=bar
    slogtest.go:36: level=INFO source=github.com/chainguard-dev/clog/slogtest/slogtest_test.go:14 msg="me again" bar=baz
    slogtest.go:36: level=INFO source=github.com/chainguard-dev/clog/slogtest/slogtest_test.go:15 msg="okay last one" baz=true
    slogtest.go:36: level=DEBUG source=github.com/chainguard-dev/clog/slogtest/slogtest_test.go:17 msg="hello debug"
    slogtest.go:36: level=INFO source=github.com/chainguard-dev/clog/slogtest/slogtest_test.go:18 msg="hello info"
    slogtest.go:36: level=WARN source=github.com/chainguard-dev/clog/slogtest/slogtest_test.go:19 msg="hello warn"
    slogtest.go:36: level=ERROR source=github.com/chainguard-dev/clog/slogtest/slogtest_test.go:20 msg="hello error"
    slogtest.go:36: level=INFO source=github.com/chainguard-dev/clog/slogtest/another_test.go:9 msg="hello from fn" foo=bar
--- PASS: TestSlogTest (0.00s)
=== RUN   TestSlogTestTContext
2025/07/08 12:29:28 INFO hello world foo=bar
2025/07/08 12:29:28 INFO me again bar=baz
2025/07/08 12:29:28 INFO okay last one baz=true
2025/07/08 12:29:28 INFO hello info
2025/07/08 12:29:28 WARN hello warn
2025/07/08 12:29:28 ERROR hello error
2025/07/08 12:29:28 INFO hello from fn foo=bar
--- PASS: TestSlogTestTContext (0.00s)
PASS
ok      github.com/chainguard-dev/clog/slogtest 0.211s
```

(debug logs are dropped, no file paths or line numbers, timestamps are added)

I don't know whether we should officially deprecate `slogtest` in favor of `clog.FromContext(t.Context())`, but at least this documents an off-ramp.