### PR TITLE
fix(ci): add persist-credentials: false and zizmor pedantic config

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,6 +24,8 @@ jobs:
         egress-policy: audit
 
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      with:
+        persist-credentials: false
 
     - name: Set up Go
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,15 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/zizmor.yml'
+      - '.github/dependabot.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/zizmor.yml'
+      - '.github/dependabot.yml'
 
 permissions: {}
 
@@ -42,3 +46,5 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        with:
+          persona: pedantic

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,8 @@
+rules:
+  dependabot-cooldown:
+    config:
+      days: 3
+  anonymous-definition:
+    disable: true
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION

## Summary

This patch series addresses GitHub Actions security findings in `chainguard-dev/clog`
as part of the PSEC-923 hardening campaign.

## Patches

### 0001 — `fix(ci): add persist-credentials: false to checkout steps`

Adds `persist-credentials: false` to the `actions/checkout` step in:

- `.github/workflows/go.yml` — build/test job; no downstream git write operations

The `zizmor.yaml` and `actionlint.yaml` workflows already had `persist-credentials: false`
on their checkout steps. This patch completes coverage for the remaining workflow.

Resolves: 1 `artipacked` finding (zizmor)

### 0002 — `fix(ci): add pedantic persona and suppress noisy zizmor rules`

- Creates `.github/zizmor.yml` disabling three pedantic-only rules that have no direct
  security value (`anonymous-definition`, `concurrency-limits`) and configuring
  `dependabot-cooldown` to use a 3-day threshold.
- Updates `.github/workflows/zizmor.yaml` to run zizmor with `persona: pedantic` so
  that all template expansions in `run:` blocks are checked, not just
  attacker-controlled ones.
- Extends the `paths:` trigger in `zizmor.yaml` to include `.github/zizmor.yml` and
  `.github/dependabot.yml`, so that changes to those files trigger the zizmor check.

Resolves: 3 `concurrency-limits` findings, 1 `anonymous-definition` finding,
2 `dependabot-cooldown` findings (all suppressed via config)

## Testing

- Validate that the zizmor workflow runs on PRs touching `.github/zizmor.yml` and
  `.github/dependabot.yml`.
- Confirm zizmor passes in pedantic mode with the new `.github/zizmor.yml` suppression
  config in place.

Refs: PSEC-923