### PR TITLE
fix: convert WARN string for cloud batch

### DIFF
--- a/gcp/setup.go
+++ b/gcp/setup.go
@@ -34,8 +34,14 @@ func NewHandlerForWriter(w io.Writer, level slog.Level) *Handler {
 			} else if a.Key == slog.LevelKey {
 				a.Key = "severity"
 				level, ok := a.Value.Any().(slog.Level)
-				if ok && level == LevelCritical {
-					a.Value = slog.StringValue("CRITICAL")
+				if ok {
+				switch {
+					case level == LevelCritical:
+						a.Value = slog.StringValue("CRITICAL")
+					case level == slog.LevelWarn:
+						// Convert WARN -> WARNING for Cloud Batch
+						a.Value = slog.StringValue("WARNING")
+					}
 				}
 			}
 			return a


### PR DESCRIPTION
### What

Convert WARN string to WARNING for compatibility with Cloud Batch

### Why

We have a service running in Cloud Batch which alerts on any warning log. Digging into this, it appears Cloud Batch does not convert WARN -> WARNING and thus interprets the unidentifiable log level as error.

Looking at logs for this service, the `jsonPayload.severity` is removed for all log levels except for WARN, which ends up interpreted as an ERROR level:
```
for level in DEBUG INFO WARN WARNING ERROR CRITICAL; do
  count=$(gcloud logging read "resource.type=\"batch.googleapis.com/Job\" labels.component=\"...\" jsonPayload.severity=\"${level}\"" \
    --project=... --limit=1 \
    --format="value(severity)" 2>/dev/null)
  echo "${level} -> ${count:-<no results>}"
done
DEBUG -> <no results>
INFO -> <no results>
WARN -> ERROR
WARNING -> <no results>
ERROR -> <no results>
CRITICAL -> <no results>
```